### PR TITLE
Added ActiveRecord 4.1 support

### DIFF
--- a/hstore-document.gemspec
+++ b/hstore-document.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<pg>, [">= 0"])
       s.add_runtime_dependency(%q<pg-hstore>, [">= 0"])
-      s.add_runtime_dependency(%q<activerecord>, ["< 4.1", ">= 3.2"])
+      s.add_runtime_dependency(%q<activerecord>, ["< 4.2", ">= 3.2"])
       s.add_development_dependency(%q<rspec>, ["~> 2.14"])
       s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0"])
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
     else
       s.add_dependency(%q<pg>, [">= 0"])
       s.add_dependency(%q<pg-hstore>, [">= 0"])
-      s.add_dependency(%q<activerecord>, ["< 4.1", ">= 3.2"])
+      s.add_dependency(%q<activerecord>, ["< 4.2", ">= 3.2"])
       s.add_dependency(%q<rspec>, ["~> 2.14"])
       s.add_dependency(%q<rdoc>, ["~> 3.12"])
       s.add_dependency(%q<bundler>, ["~> 1.0"])
@@ -77,7 +77,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<pg>, [">= 0"])
     s.add_dependency(%q<pg-hstore>, [">= 0"])
-    s.add_dependency(%q<activerecord>, ["< 4.1", ">= 3.2"])
+    s.add_dependency(%q<activerecord>, ["< 4.2", ">= 3.2"])
     s.add_dependency(%q<rspec>, ["~> 2.14"])
     s.add_dependency(%q<rdoc>, ["~> 3.12"])
     s.add_dependency(%q<bundler>, ["~> 1.0"])
@@ -88,4 +88,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<guard-rspec>, [">= 0"])
   end
 end
-

--- a/lib/active_record/associations/builder/embeds_one.rb
+++ b/lib/active_record/associations/builder/embeds_one.rb
@@ -12,6 +12,10 @@ module ActiveRecord
         def macro
           :embeds_one
         end
+
+        def valid_options
+          super + [:class_name]
+        end
       end
     end
   end

--- a/lib/active_record/associations/embeds_one_association.rb
+++ b/lib/active_record/associations/embeds_one_association.rb
@@ -2,17 +2,32 @@ require 'active_record/associations/association'
 
 module ActiveRecord
   module Associations
-    module ClassMethods
-      # @param [Symbol, String] name of association
-      # @param [Hash] options
-      # @option options [Boolean] :validate Validate associaited object (default: true)
-      # @option options [String] :class_name Name of the associated class
-      def embeds(name, options = {})
-        validates_associated(name) unless options.delete(:validate) == false
-        if ActiveRecord::VERSION::MAJOR < 4
-          Builder::EmbedsOne.build(self, name, options)
-        else
-          Builder::EmbedsOne.build(self, name, options, nil)
+    if (ActiveRecord.version.segments[0] + ActiveRecord.version.segments[1] / 10.0) >= 4.1
+      module ClassMethods
+        # @param [Symbol, String] name of association
+        # @param scope
+        # @param [Hash] options
+        # @option options [Boolean] :validate Validate associaited object (default: true)
+        # @option options [String] :class_name Name of the associated class
+        def embeds(name, scope = nil, options = {}, &extension)
+          validates_associated(name) unless options.delete(:validate) == false
+          reflection = Builder::EmbedsOne.build(self, name, options, nil)
+          Reflection.add_reflection self, name, reflection
+        end
+      end
+    else
+      module ClassMethods
+        # @param [Symbol, String] name of association
+        # @param [Hash] options
+        # @option options [Boolean] :validate Validate associaited object (default: true)
+        # @option options [String] :class_name Name of the associated class
+        def embeds(name, options = {})
+          validates_associated(name) unless options.delete(:validate) == false
+          if ActiveRecord::VERSION::MAJOR < 4
+            Builder::EmbedsOne.build(self, name, options)
+          else
+            Builder::EmbedsOne.build(self, name, options, nil)
+          end
         end
       end
     end

--- a/lib/active_record/embeds_reflection.rb
+++ b/lib/active_record/embeds_reflection.rb
@@ -3,38 +3,71 @@ require 'active_record/reflection'
 
 module ActiveRecord
   module Reflection
-    class AssociationReflection # :nodoc:
-      def association_class_with_embeds_one
-        if macro == :embeds_one
-          Associations::EmbedsOneAssociation
-        else
-          association_class_without_embeds_one
+    if (ActiveRecord.version.segments[0] + ActiveRecord.version.segments[1] / 10.0) >= 4.1
+      class EmbedsOneReflection < AssociationReflection # :nodoc:
+        def initialize(name, scope, options, active_record)
+          super(macro, name, scope, options, active_record)
         end
-      end
-      alias_method_chain :association_class, :embeds_one
-    end
 
-    module ClassMethods # :nodoc:
-      if ActiveRecord::VERSION::MAJOR < 4
-        def create_reflection_with_embeds(macro, name, options, active_record)
-          unless macro == :embeds_one
-            return create_reflection_without_embeds(macro, name, options, active_record)
-          end
-          AssociationReflection.new(macro, name, options, active_record).tap do |reflection|
-            reflections.merge!(name => reflection)
-          end
-        end
-      else
-        def create_reflection_with_embeds(macro, name, scope, options, active_record)
-          unless macro == :embeds_one
-            return create_reflection_without_embeds(macro, name, scope, options, active_record)
-          end
-          AssociationReflection.new(macro, name, scope, options, active_record).tap do |reflection|
-            reflections.merge!(name => reflection)
+        def macro; :embeds_one; end
+
+        def embeds_one?; true; end
+
+        def association_class_with_embeds_one
+          if macro == :embeds_one
+            Associations::EmbedsOneAssociation
+          else
+            association_class_without_embeds_one
           end
         end
+
+        alias_method_chain :association_class, :embeds_one
       end
-      alias_method_chain :create_reflection, :embeds
+
+      class << self
+        def create_with_embeds(macro, name, scope, options, active_record)
+          unless macro == :embeds_one
+            return create_without_embeds(macro, name, scope, options, active_record)
+          end
+          EmbedsOneReflection.new(name, scope, options, active_record)
+        end
+
+        alias_method_chain :create, :embeds
+      end
+    else
+      class AssociationReflection # :nodoc:
+        def association_class_with_embeds_one
+          if macro == :embeds_one
+            Associations::EmbedsOneAssociation
+          else
+            association_class_without_embeds_one
+          end
+        end
+        alias_method_chain :association_class, :embeds_one
+      end
+
+      module ClassMethods # :nodoc:
+        if ActiveRecord::VERSION::MAJOR < 4
+          def create_reflection_with_embeds(macro, name, options, active_record)
+            unless macro == :embeds_one
+              return create_reflection_without_embeds(macro, name, options, active_record)
+            end
+            AssociationReflection.new(macro, name, options, active_record).tap do |reflection|
+              reflections.merge!(name => reflection)
+            end
+          end
+        else
+          def create_reflection_with_embeds(macro, name, scope, options, active_record)
+            unless macro == :embeds_one
+              return create_reflection_without_embeds(macro, name, scope, options, active_record)
+            end
+            AssociationReflection.new(macro, name, scope, options, active_record).tap do |reflection|
+              reflections.merge!(name => reflection)
+            end
+          end
+        end
+        alias_method_chain :create_reflection, :embeds
+      end
     end
   end
 end

--- a/lib/hstore/document.rb
+++ b/lib/hstore/document.rb
@@ -166,7 +166,7 @@ module Hstore
     module ClassMethods
 
       def from_hstore(data)
-        if ActiveRecord::VERSION::MAJOR < 4
+        if ActiveRecord.version.segments[0] < 4
           data = PgHstore.load(data)
         end
         new(data, serialized: true)


### PR DESCRIPTION
Just found your project last night. It's just what we were looking for! We're on the latest rails so things didn't quite work out the box. I pulled down the rails source code and compared 4.0 to 4.1 and there seemed to be quite a few differences in it. Here is a brief summary of the changes I made.
- ActiveRecord::VERSION is no longer there. I couldn't tell immediately if it was moved somewhere else but I started using ActiveRecord.version.segments which isn't the sexiest of solutions.
- Updated association embed class to match what I'm seeing in 4.1 including calling out Reflection.add_reflection
- Created the EmbedsOneReflection class to match the other classes I see now in 4.1 (BelongsToReflection, HasManyReflection.) This is instead of changing AssociationReflection.
- Moved create_reflection no the instant to create on the class

Let me know what you think.
